### PR TITLE
rev pgsqltools version to 1.10.0, update exe name, add osx ARM runtime

### DIFF
--- a/src/configurations/dev.config.json
+++ b/src/configurations/dev.config.json
@@ -1,11 +1,12 @@
 {
     "service": {
         "downloadUrl": "https://github.com/Microsoft/pgtoolsservice/releases/download/{#version#}/pgsqltoolsservice-{#fileName#}",
-        "version": "v1.1.0",
+        "version": "v1.10.0",
         "downloadFileNames": {
             "Windows_7_86": "win-x86.zip",
             "Windows_7_64": "win-x64.zip",
             "OSX_10_11_64": "osx.tar.gz",
+            "OSX_10_11_ARM": "osx-arm64.tar.gz",
             "CentOS_7": "linux-x64.tar.gz",
             "Debian_8": "linux-x64.tar.gz",
             "Fedora_23": "linux-x64.tar.gz",
@@ -17,8 +18,8 @@
         },
         "installDir": "../pgsqltoolsservice/{#version#}/{#platform#}",
         "executableFiles": [
-            "pgsqltoolsservice/pgtoolsservice_main",
-            "pgsqltoolsservice/pgtoolsservice_main.exe"
+            "pgsqltoolsservice/ossdbtoolsservice_main",
+            "pgsqltoolsservice/ossdbtoolsservice_main.exe"
         ]
     }
 }

--- a/src/configurations/production.config.json
+++ b/src/configurations/production.config.json
@@ -1,11 +1,12 @@
 {
     "service": {
         "downloadUrl": "https://github.com/Microsoft/pgtoolsservice/releases/download/{#version#}/pgsqltoolsservice-{#fileName#}",
-        "version": "v1.1.0",
+        "version": "v1.10.0",
         "downloadFileNames": {
             "Windows_7_86": "win-x86.zip",
             "Windows_7_64": "win-x64.zip",
             "OSX_10_11_64": "osx.tar.gz",
+            "OSX_10_11_ARM": "osx-arm64.tar.gz",
             "CentOS_7": "linux-x64.tar.gz",
             "Debian_8": "linux-x64.tar.gz",
             "Fedora_23": "linux-x64.tar.gz",
@@ -17,8 +18,8 @@
         },
         "installDir": "../pgsqltoolsservice/{#version#}/{#platform#}",
         "executableFiles": [
-            "pgsqltoolsservice/pgtoolsservice_main",
-            "pgsqltoolsservice/pgtoolsservice_main.exe"
+            "pgsqltoolsservice/ossdbtoolsservice_main",
+            "pgsqltoolsservice/ossdbtoolsservice_main.exe"
         ]
     }
 }

--- a/src/models/platform.ts
+++ b/src/models/platform.ts
@@ -18,7 +18,8 @@ export enum Runtime {
     UnknownVersion = <any>'Unknown',
     Windows_7_86 = <any>'Windows_7_86',
     Windows_7_64 = <any>'Windows_7_64',
-    OSX_10_11_64 = <any> 'OSX_10_11_64',
+    OSX_10_11_64 = <any>'OSX_10_11_64',
+    OSX_10_11_ARM = <any>'OSX_10_11_ARM',
     CentOS_7 = <any>'CentOS_7',
     Debian_8 = <any>'Debian_8',
     Fedora_23 = <any>'Fedora_23',
@@ -36,6 +37,7 @@ export function getRuntimeDisplayName(runtime: Runtime): string {
         case Runtime.Windows_7_86:
             return 'Windows';
         case Runtime.OSX_10_11_64:
+        case Runtime.OSX_10_11_ARM:
             return 'OSX';
         case Runtime.CentOS_7:
             return 'CentOS';
@@ -54,7 +56,7 @@ export function getRuntimeDisplayName(runtime: Runtime): string {
         case Runtime.Ubuntu_16:
             return 'Ubuntu16';
         default:
-        return 'Unknown';
+            return 'Unknown';
     }
 }
 
@@ -153,7 +155,7 @@ export class PlatformInformation {
                 throw new Error(`Unsupported platform: ${platform}`);
         }
 
-        return architecturePromise.then( arch => {
+        return architecturePromise.then(arch => {
             return distributionPromise.then(distro => {
                 return new PlatformInformation(platform, arch, distro);
             });
@@ -162,11 +164,11 @@ export class PlatformInformation {
 
     private static GetWindowsArchitecture(): Promise<string> {
         return new Promise<string>((resolve, reject) => {
-             if (process.env.PROCESSOR_ARCHITECTURE === 'x86' && process.env.PROCESSOR_ARCHITEW6432 === undefined) {
-                 resolve('x86');
-             } else {
-                 resolve('x86_64');
-             }
+            if (process.env.PROCESSOR_ARCHITECTURE === 'x86' && process.env.PROCESSOR_ARCHITEW6432 === undefined) {
+                resolve('x86');
+            } else {
+                resolve('x86_64');
+            }
         });
     }
 
@@ -218,11 +220,12 @@ export class PlatformInformation {
                 throw new Error(`Unsupported Windows architecture: ${architecture}`);
 
             case 'darwin':
-                if (architecture === 'x86_64') {
+                switch (architecture) {
                     // Note: We return the El Capitan RID for Sierra
-                    return Runtime.OSX_10_11_64;
+                    case 'x86_64': return Runtime.OSX_10_11_64;
+                    case 'arm64': return Runtime.OSX_10_11_ARM;
+                    default:
                 }
-
                 throw new Error(`Unsupported macOS architecture: ${architecture}`);
 
             case 'linux':
@@ -251,10 +254,10 @@ export class PlatformInformation {
 
                 // If we got here, this is not a Linux distro or architecture that we currently support.
                 throw new Error(`Unsupported Linux distro: ${distribution.name}, ${distribution.version}, ${architecture}`);
-            default :
-                 // If we got here, we've ended up with a platform we don't support  like 'freebsd' or 'sunos'.
-                 // Chances are, VS Code doesn't support these platforms either.
-                 throw Error('Unsupported platform ' + platform);
+            default:
+                // If we got here, we've ended up with a platform we don't support  like 'freebsd' or 'sunos'.
+                // Chances are, VS Code doesn't support these platforms either.
+                throw Error('Unsupported platform ' + platform);
         }
     }
 


### PR DESCRIPTION
The tools version 1.1.0 (in the original extension) are too old to support Apple arm64; later revisions do support arm64 but use a different executable name. This PR:

- updates config to use v1.10.0 of the pgsqltoolsservice (latest as of 2024/01)
- updates the name of the executable used from `pgtoolsservice_main` to `ossdbtoolsservice_main` (to reflect the change in pgtoolsservice)
- adds an arm64 runtime identifier to download the correct file name