### PR TITLE
Correct README.md Quickstart instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Install link: https://marketplace.visualstudio.com/items?itemName=ms-ossdata.vsc
 
 2) Search and select 'PostgreSQL: New Query'
 
-3) In the command palette, select 'Create Connection Profile'. Follow the prompts to enter your Postgres instance's hostname, database, username, and password.
+3) In the command palette, select 'Manage Connection Profiles'. Follow the prompts to enter your Postgres instance's hostname, database, username, and password.
 
 You are now connected to your Postgres database. You can confirm this via the Status Bar (the ribbon at the bottom of the VS Code window). It will show your connected hostname, database, and user.
 


### PR DESCRIPTION
Refer to issue: Quickstart instructions are inaccurate #121. Quickstart instruction 'Create Connection Profile" should be  "Manage Connection Profiles".